### PR TITLE
Re-submitting HW assignment

### DIFF
--- a/h2/src/main/org/h2/expression/Subquery.java
+++ b/h2/src/main/org/h2/expression/Subquery.java
@@ -89,7 +89,9 @@ public final class Subquery extends Expression {
 
     @Override
     public void mapColumns(ColumnResolver resolver, int level, int state) {
-        outerResolvers.add(resolver);
+        if (outerResolvers != null) {
+            outerResolvers.add(resolver);
+        }
         query.mapColumns(resolver, level + 1, true);
     }
 


### PR DESCRIPTION
## Problem 1 - Recent Posts 
 
<change you made>
I created an index idx_post_timestamp for the post_timestamp field, which avoids a full table scan and speeds up the execution of the ORDER BY statement.
CREATE INDEX idx_post_timestamp ON posts (post_timestamp DESC);
EXPLAIN ANALYZE
SELECT
 post_id,
 post_timestamp
 
FROM
 posts
 
ORDER BY
 post_timestamp DESC
 
LIMIT 10 
<screenshot of EXPLAIN ANALYZE>


 
## Problem 2 - Somewhat Strange Query
 
<change you made>
CREATE INDEX idx_content ON posts (content);
CREATE INDEX idx_post_timestamp ON posts (post_timestamp);
CREATE INDEX idx_author ON posts (author);
SET TRACE_LEVEL_SYSTEM_OUT 3;
SET CACHE_SIZE 0;
SET MAX_MEMORY_ROWS 0;
SET MAX_MEMORY_UNDO 0;
EXPLAIN ANALYZE
SELECT
    post_id,
    post_timestamp
 
FROM
    posts
 
WHERE
    UPPER(content) LIKE 'C%'
    AND post_timestamp < '2024-02-01'
    AND SUBSTR(author, 3, 3) = 'son';
<screenshot of EXPLAIN ANALYZE>
 
## Problem 3 - Really Fast Single Row Responses
### Problem 3.1 

<What index does H2DB end up using?  Explain the pros and cons of each index that you created.>
I use hash index.
 B-Tree Index
CREATE INDEX idx_post_timestamp ON posts (post_timestamp);
Wide range of support for exact match (=) and range queries (<, >, BETWEEN), and for ORDER BY, aggregated queries, etc.Query time increases linearly with the amount of data (much faster than a full table scan). Can support range queries.
Because it is an ordered index, it may be slightly slower than a hash index for a fully-equivalent query (=).
Hash index
CREATE HASH INDEX idx_post_timestamp ON posts (post_timestamp);
Hash index lookups are extremely fast and have O(1) time complexity. Best for exact match queries.
Does not support range queries and cannot be used for ORDER BY or BETWEEN.Limited choice of query optimizers, indexes may be invalid if the query is slightly different.

### Problem 3.2 
﻿
<Which of the indexes that you created for 3.1 would you expect to be used now.  Please explain.>
I use B-Tree index.
CREATE INDEX idx_post_timestamp ON posts (post_timestamp);
The B-Tree index (idx_post_timestamp) will be used by H2DB because it supports range queries.
The Hash index (idx_post_timestamp) will not be used because BETWEEN requires range scans and Hash is only available for = queries.

### Problem 3.3
 
<Can you modify one of the indexes from 3.2 to make this query even faster?  Explain why your change to the index made the query even faster.>
CREATE INDEX idx_post_timestamp ON posts (post_timestamp);
 
idx_post_timestamp_content is a composite index of post_timestamp, content instead of a separate content index.It is more efficient than creating a separate index for content because it not only filters the data by post_timestamp, but also returns the content directly, avoiding the need to go back to the table.

CREATE INDEX idx_post_timestamp_content ON posts (post_timestamp, content);

## Problem 4 - Table Join Order
### Problem 4.1 
 
<Your modified query here>
SELECT COUNT(1)
FROM users
JOIN followers ON users.handle = followers.follower_handle
JOIN posts ON followers.following_handle = posts.author
WHERE users.last_name = 'Anderson'
AND users.first_name = 'Abigail';
 
### Problem 4.2
 
<List each of the four possible join orders and explain why or why not that particular join order will perform well or poorly.>
1.
SELECT COUNT(1)
FROM users
JOIN followers ON users.handle = followers.follower_handle
JOIN posts ON followers.following_handle = posts.author
WHERE users.last_name = 'Anderson'
AND users.first_name = 'Abigail';
First filter users, only deal with Abigail Anderson, small amount of data.
Then JOIN followers, only keep the users that Abigail follows, reduce the amount of data.
Finally, JOIN posts, only count the posts of Abigail's followers.
2.
SELECT COUNT(1)
FROM followers
JOIN users ON followers.follower_handle = users.handle
JOIN posts ON followers.following_handle = posts.author
WHERE users.last_name = 'Anderson'
AND users.first_name = 'Abigail';

Followers is a large table, and if you JOIN followers first, the database has to deal with a lot of extraneous data.
users filters too late, resulting in a large JOIN calculation.
Much slower than users → followers → posts.
3.
SELECT COUNT(1)
FROM followers
JOIN posts ON followers.following_handle = posts.author
JOIN users ON followers.follower_handle = users.handle
WHERE users.last_name = 'Anderson'
AND users.first_name = 'Abigail';

JOIN followers and posts first, which may result in scanning the entire posts table, which is a huge amount of data.
Filter users last, but by this time the data is already too large and the filtering is very ineffective.
4.
SELECT COUNT(1)
FROM posts
JOIN followers ON posts.author = followers.following_handle
JOIN users ON followers.follower_handle = users.handle
WHERE users.last_name = 'Anderson'
AND users.first_name = 'Abigail';

Posts is probably the largest table, and if you JOIN first, the query will be very slow.
The database would have to scan posts, match followers, and then filter users, but then users would be filtered too late and the query would be slow.



 
## Problem 5 - Putting it All Together - Fast Most Recent Posts 
 
<your query here>
CREATE INDEX idx_followers_follower ON followers(follower_handle);
CREATE INDEX idx_posts_author_timestamp ON posts(author, post_timestamp DESC);
WITH latest_posts AS (
    SELECT 
        p.post_id, 
        p.author, 
        p.post_timestamp, 
        p.content,
        ROW_NUMBER() OVER (PARTITION BY p.author ORDER BY p.post_timestamp DESC) AS rn
    FROM posts p
    JOIN followers f ON p.author = f.following_handle
    WHERE f.follower_handle = 'madison.anderson9901'
)
SELECT post_id, author, post_timestamp, content
FROM latest_posts
WHERE rn = 1
ORDER BY post_timestamp DESC;



<img width="415" alt="Screenshot 2025-02-28 at 11 46 15 PM" src="https://github.com/user-attachments/assets/2fdd9f2f-c67d-469a-b2b2-7ece68621e9e" />
<img width="491" alt="Screenshot 2025-02-28 at 11 46 27 PM" src="https://github.com/user-attachments/assets/342cbc7a-9216-4a6f-9c14-a0fdbf297625" />
<img width="350" alt="Screenshot 2025-02-28 at 11 46 36 PM" src="https://github.com/user-attachments/assets/6cdc4a5e-73b0-4d55-8f28-d70c7ea2f490" />
<img width="409" alt="Screenshot 2025-02-28 at 11 46 44 PM" src="https://github.com/user-attachments/assets/10ae2685-d145-4ce1-a65f-242e9499b780" />
